### PR TITLE
gemspec: Update licenses field

### DIFF
--- a/rack-noindex.gemspec
+++ b/rack-noindex.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files app lib`.split("\n")
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
-  s.rubyforge_project = '[none]'
+  s.licenses      = ['MIT']
   s.add_dependency 'rack'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rack-test'


### PR DESCRIPTION
This PR places the license in the RubyGems metadata.

  - drop the rubyforge-related field