### PR TITLE
Fix the build: hold back rack-test; introduce test-unit gem; update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-18mode
-  - jruby-19mode
+  - jruby-9.1.13.0
   - jruby-head
   - ruby-head
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - rbx-18mode
-  - rbx-19mode
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - jruby-18mode
   - jruby-19mode
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
@@ -15,3 +14,5 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+cache:
+  bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gemspec
+ruby RUBY_VERSION
 
-gem 'rack', '< 2.0'
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 gem 'rack-test', '< 0.7'
 gem 'rack', '< 2.0'
+gem "test-unit", "1.2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+gem 'rack-test', '< 0.7'
+gem 'rack', '< 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
-gem 'rack-test', '< 0.7'
+
 gem 'rack', '< 2.0'
-gem 'test-unit', '1.2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gemspec
 gem 'rack-test', '< 0.7'
 gem 'rack', '< 2.0'
-gem "test-unit", "1.2.3"
+gem 'test-unit', '1.2.3'

--- a/rack-noindex.gemspec
+++ b/rack-noindex.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rack-test', '< 0.7'
   s.add_development_dependency 'contest'
-  s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'test-unit', '= 1.2.3'  # the version to ship with 1.8.7
 end

--- a/rack-noindex.gemspec
+++ b/rack-noindex.gemspec
@@ -14,11 +14,12 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files app lib`.split("\n")
   s.platform      = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 1.9.2'
   s.require_paths = ['lib']
   s.rubyforge_project = '[none]'
   s.add_dependency 'rack'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rack-test', '< 0.7'
   s.add_development_dependency 'contest'
-  s.add_development_dependency 'test-unit', '= 1.2.3'  # the version to ship with 1.8.7
+  s.add_development_dependency 'test-unit'
 end

--- a/rack-noindex.gemspec
+++ b/rack-noindex.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rack-test', '< 0.7'
   s.add_development_dependency 'contest'
-  s.add_development_dependency 'test-unit', '1.2.3'
+  s.add_development_dependency 'test-unit'
 end

--- a/rack-noindex.gemspec
+++ b/rack-noindex.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.add_dependency 'rack'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rack-test', '< 0.7'
   s.add_development_dependency 'contest'
+  s.add_development_dependency 'test-unit', '1.2.3'
 end


### PR DESCRIPTION
This PR ~wants to fix~ fixes the build.

In the **Gemfile**:

- fix current Ruby version as a Bundler constraint on which packages are to be picked

In the **gemspec**:

- pin rack-test to < 0.7
- introduce test-unit as a gem

In the **Travis CI matrix**:

- drop 1.8.7
- drop rbx-19mode, rbx-18mode
- drop jruby-18mode, jruby-19mode (rvm translates them into jruby-9.1.7.0)
- add jruby-9.1.13.0
- add all pre-installed-on-Travis MRI rubies
